### PR TITLE
[Issue #1] Use the game folder instead of the stories folder

### DIFF
--- a/src/loader.ps1
+++ b/src/loader.ps1
@@ -212,7 +212,7 @@ function getSettings() {
         $newSettings.SettingsVersion = 1;
 
         # Prompt the user for the path to their game folder. Use the default path if none is provided.
-        $userGameDirectory = Read-Host -Prompt "Please enter the path of your game directory. Press enter to use the default value: $($defaultPathToGameFolder)"
+        $userGameDirectory = Read-Host -Prompt "Please provide the path of your game directory. Leave blank to use the default value: $($defaultPathToGameFolder)"
 
         # Append the Stories folder to the base game path
         if ($userGameDirectory -eq "") {

--- a/src/loader.ps1
+++ b/src/loader.ps1
@@ -18,6 +18,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # User settings, persisting between runs
 [string] $settingsPath = ".\settings.json"
+[string] $defaultPathToGameFolder = "$(${ENV:ProgramFiles(x86)})\Steam\steamapps\common\Exocolonist"
+[string] $storiesFolderPathSuffix = "Exocolonist_Data\StreamingAssets\Stories"
 
 class ExomodLoaderSettingsFile {
     [int] $SettingsVersion
@@ -208,7 +210,17 @@ function getSettings() {
     if (!$isSettingsFromFile) {
         $newSettings = [ExomodLoaderSettingsFile]::new()
         $newSettings.SettingsVersion = 1;
-        $newSettings.PathToGameStoriesFolder = Read-Host -Prompt "Please enter the path of your game's unmodified Stories directory. Example: $(${ENV:ProgramFiles(x86)})\Steam\steamapps\common\Exocolonist\Exocolonist_Data\StreamingAssets\Stories"
+
+        # Prompt the user for the path to their game folder. Use the default path if none is provided.
+        $userGameDirectory = Read-Host -Prompt "Please enter the path of your game directory. Press enter to use the default value: $($defaultPathToGameFolder)"
+
+        # Append the Stories folder to the base game path
+        if ($userGameDirectory -eq "") {
+            $newSettings.PathToGameStoriesFolder = "$defaultPathToGameFolder\$storiesFolderPathSuffix"
+        } else {
+            $newSettings.PathToGameStoriesFolder = "$userGameDirectory\$storiesFolderPathSuffix"
+        }
+
         validateStoriesFolderPath($newSettings.PathToGameStoriesFolder)
         Write-Host "New loader settings look good! Saving to settings.json for future use..."
 


### PR DESCRIPTION
# Description

- In setup, prompt user for game folder instead of stories folder
- Supply a default value if the user enters an empty string
Fixes #1 

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Run locally, and successfully loaded a mod after each test:
- Without a settings file, and provided a path. Settings were persisted successfully.
- Without a settings file, and provided an empty string. The new default path setting was applied successfully.
- With an existing settings file. The script skipped the prompt for a path as expected before this patch.

# Checklist:

- [x] I have performed a self-review of my own diff
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have included corresponding changes to the documentation

# Screenshots

Please include screenshots if applicable, especially when user interfaces have been updated.